### PR TITLE
Simplify build script in package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vue-tsc -b && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
Using it in frappe cloud fails with below exception

> frontend@0.0.0 build
> vue-tsc -b && vite build

src/components/fui/TextInput.vue(58,7): error TS2322: Type 'import("/home/frappe/frappe-bench/apps/otto/frontend/node_modules/@vue/runtime-core/dist/runtime-core").Attrs' is not assignable to type 'Attrs'.
  Types of property 'class' are incompatible.
    Type 'ClassValue' is not assignable to type 'string | string[] | Record<string, boolean> | undefined'.
      Type 'null' is not assignable to type 'string | string[] | Record<string, boolean> | undefined'.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command. Error: Command failed: yarn build
    at checkExecSyncError (node:child_process:885:11)
    at execSync (node:child_process:957:15)
    at run_build_command_for_apps (/home/frappe/frappe-bench/apps/frappe/esbuild/esbuild.js:453:5)
    at execute (/home/frappe/frappe-bench/apps/frappe/esbuild/esbuild.js:125:23) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 199,
  stdout: null,
  stderr: null
}